### PR TITLE
도움 제공자에게 인증 완료 알림을 위한 웹소켓 통신 구현

### DIFF
--- a/carea/helps/consumers.py
+++ b/carea/helps/consumers.py
@@ -61,7 +61,7 @@ class HelpConsumer(AsyncWebsocketConsumer):
                 print(await self.check_helper(room))
                 if not await self.check_helper(room):
                     print('도움 제공자만 인증할 문장을 보낼 수 있습니다.')
-                    await self.send(text_data=json.dumps({'isSuccess': False, 'message': '도움 요청자만 인증할 문장을 말할 수 있습니다.'}))
+                    await self.send(text_data=json.dumps({'isSuccess': False, 'message': '도움 제공자만 인증할 문장을 보낼 수 있습니다.'}))
                     await self.close()
 
                 content = json.loads(text_data)


### PR DESCRIPTION
## 📍 Issue 번호

<!-- 관련있는 이슈 번호(#nn)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->

> closed #41 

## 🛠️ PR 세부 내용

<!-- 작업한 내용을 적어주세요.  -->
- 도움 요청자가 도움 제공자에게 인증 완료 알림을 보낼 수 있도록 변경

## 🚨 주의 사항
- 텍스트 메시지 보낸 사람이 도움 제공자인 경우, 기존처럼 인증 문장 DB에 저장 후 웹 소켓에 전달 (나중에 서버에서 STT할 경우를 위해 DB에 저장하는 코드는 지우지 않음)
- 텍스트 메시지(ex. "인증 완료") 보낸 사람이 도움 요청자인 경우, 해당 텍스트 메시지 그대로 웹 소켓에 전달

<!--
## 📢 추가 의논 사항
- 추가적으로 의논할 사항이나 발생한 에러에 대한 설명

## 📸 스크린샷 -->
